### PR TITLE
Resize the track tiles using CSS instead of javascript

### DIFF
--- a/app/assets/javascripts/gallery.js.coffee
+++ b/app/assets/javascripts/gallery.js.coffee
@@ -1,6 +1,5 @@
 class @Gallery
   constructor: (@player) ->
-    @resizeTracksHeight()
     @player.observe('play', @play.bind(this))
     @player.observe('pause', @pause.bind(this))
     @initializeEvents()
@@ -10,12 +9,7 @@ class @Gallery
     $('.tracks').on('DOMNodeInserted', @trackAdded.bind(this))
     $('.tracks').on('dragover', @dragOverTrack.bind(this))
     $('.tracks').on('drop', @dropTrack.bind(this))
-    $(window).resize(@resizeTracksHeight.bind(this))
     @listenTrackEvents($('.tracks'))
-    @resizeTracksHeight()
-
-  resizeTracksHeight: () ->
-    setTimeout( -> $('.track').height($('.track').width()))
 
   listenTrackEvents: (collection) ->
     collection.find('[data-action=play]').on('click', @clickOnPlay.bind(this))

--- a/app/assets/stylesheets/base.css
+++ b/app/assets/stylesheets/base.css
@@ -22,13 +22,24 @@ a:active { color: #666; }
 
 .track {
   position: relative;
-  margin: 0;
+  display: block;
   float: left;
-  background: no-repeat;
-  background-size: 200px 200px;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+
+  background-color: #111;
+
   transition: all 0.25s ease-in-out;
   -webkit-transition: all 0.25s ease-in-out;
   -moz-transition: all 0.25s ease-in-out;
+  overflow: hidden;
+}
+
+.track .cover-art {
+  display: block;
+  width: 200px;
+  max-width: 100%;
 }
 
 .track.paused, .track.playing {
@@ -93,13 +104,19 @@ a:active { color: #666; }
   background: rgba(160, 160, 160, 1);
 }
 
+.track .controls.container {
+  position: absolute;
+  top: 0;
+  width: 100%;
+  height: 100%;
+}
+
 .track .primary.controls {
   /* TODO: Hackish center */
+  position: relative;
+  top: 30%;
   width: 64px;
   height: 64px;
-  top: 68px;
-  display: block;
-  position: relative;
   margin: 0 auto;
 }
 
@@ -215,14 +232,6 @@ footer section.settings {
   text-align: center;
   font-size: 36pt;
   font-weight: bold;
-}
-
-.track {
-  display: block;
-  float: left;
-  margin: 0;
-  padding: 0;
-  width: 100%;
 }
 
 /* TODO: Overlap track cover. */

--- a/app/views/favorites/_favorite.html.erb
+++ b/app/views/favorites/_favorite.html.erb
@@ -7,20 +7,22 @@
   data-stream-url="<%= favorite.track.stream_url %>"
   data-origin-url="<%= favorite.track.url %>"
   data-title="<%= favorite.track.title %>"
-  data-artist="<%= favorite.track.artist %>"
-  style="background-image: url('<%= favorite.track.cover_url %>')">
-  <div class="primary controls">
-    <span class="iconic play" data-action="play" data-target="favorite_<%= favorite.id %>" title="Play"></span>
-    <span class="iconic pause" data-action="pause" data-target="favorite_<%= favorite.id %>" title="Pause"></span>
-  </div>
-  <div class="secondary controls">
-    <% if current_user && current_user == @user %>
-      <span class="iconic trash_stroke" data-action="delete" data-target="favorite_<%= favorite.id %>" title="Delete"></span>
-      <span class="iconic move" data-action="move" data-target="favorite_<%= favorite.id %>" draggable="true" title="Move"></span>
-    <% end %>
-    <% if current_user && current_user != @user %>
-      <span class="iconic plus" data-action="import" data-target="favorite_<%= favorite.id %>" title="Import to your playlist"></span>
-    <% end %>
-    <a href="<%= favorite.track.url %>" class="iconic link" target="_blank" title="Official page"></a>
+  data-artist="<%= favorite.track.artist %>">
+  <img src="<%= favorite.track.cover_url %>" class="cover-art">
+  <div class="controls container">
+    <div class="primary controls">
+      <span class="iconic play" data-action="play" data-target="favorite_<%= favorite.id %>" title="Play"></span>
+      <span class="iconic pause" data-action="pause" data-target="favorite_<%= favorite.id %>" title="Pause"></span>
+    </div>
+    <div class="secondary controls">
+      <% if current_user && current_user == @user %>
+        <span class="iconic trash_stroke" data-action="delete" data-target="favorite_<%= favorite.id %>" title="Delete"></span>
+        <span class="iconic move" data-action="move" data-target="favorite_<%= favorite.id %>" draggable="true" title="Move"></span>
+      <% end %>
+      <% if current_user && current_user != @user %>
+        <span class="iconic plus" data-action="import" data-target="favorite_<%= favorite.id %>" title="Import to your playlist"></span>
+      <% end %>
+      <a href="<%= favorite.track.url %>" class="iconic link" target="_blank" title="Official page"></a>
+    </div>
   </div>
 </div>

--- a/app/views/tracks/_track.html.erb
+++ b/app/views/tracks/_track.html.erb
@@ -6,20 +6,22 @@
   data-stream-url="<%= track.stream_url %>"
   data-origin-url="<%= track.url %>"
   data-title="<%= track.title %>"
-  data-artist="<%= track.artist %>"
-  style="background-image: url('<%= track.cover_url %>')">
-  <div class="primary controls">
-    <span class="iconic play" data-action="play" data-target="track_<%= track.id %>" title="Play"></span>
-    <span class="iconic pause" data-action="pause" data-target="track_<%= track.id %>" title="Pause"></span>
-  </div>
-  <div class="secondary controls">
-    <% if current_user && current_user == @user %>
-      <span class="iconic trash_stroke" data-action="delete" data-target="track_<%= track.id %>" title="Delete"></span>
-      <span class="iconic move" data-action="move" data-target="track_<%= track.id %>" draggable="true" title="Move"></span>
-    <% end %>
-    <% if current_user && current_user != @user %>
-      <span class="iconic plus" data-action="import" data-target="track_<%= track.id %>" title="Import to your playlist"></span>
-    <% end %>
-    <a href="<%= track.url %>" class="iconic link" target="_blank" title="Official page"></a>
+  data-artist="<%= track.artist %>">
+  <img src="<%= track.cover_url %>" class="cover-art">
+  <div class="controls container">
+    <div class="primary controls">
+      <span class="iconic play" data-action="play" data-target="track_<%= track.id %>" title="Play"></span>
+      <span class="iconic pause" data-action="pause" data-target="track_<%= track.id %>" title="Pause"></span>
+    </div>
+    <div class="secondary controls">
+      <% if current_user && current_user == @user %>
+        <span class="iconic trash_stroke" data-action="delete" data-target="track_<%= track.id %>" title="Delete"></span>
+        <span class="iconic move" data-action="move" data-target="track_<%= track.id %>" draggable="true" title="Move"></span>
+      <% end %>
+      <% if current_user && current_user != @user %>
+        <span class="iconic plus" data-action="import" data-target="track_<%= track.id %>" title="Import to your playlist"></span>
+      <% end %>
+      <a href="<%= track.url %>" class="iconic link" target="_blank" title="Official page"></a>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
The trick here is to include the cover art as <img> instead of a background image. The browser knows how to resize images while keeping the aspect ratio, and this keeps the tiles square without readjusting the height with javascript.

The drawback is that the code relies on the square dimensions of the cover art, but square cover art is a well-established convention.
